### PR TITLE
Use artefactual/clamav docker image

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       - "archivematica_pipeline_data:/var/archivematica/sharedDirectory:rw"  # Read and write needed!
 
   clamavd:
-    image: "dinkel/clamavd:latest"
+    image: "artefactual/clamav:latest"
     expose:
       - "3310"
     ports:


### PR DESCRIPTION
This change has been applied to fix the Jisc issue [#68](https://github.com/JiscRDSS/rdss-archivematica/issues/68)