### PR TITLE
Makes naming of CLAMAV_BACKEND variable compliant with AM guidelines

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -144,7 +144,7 @@ services:
       ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_CLIENT_MAX_FILE_SIZE: "${CLAMAV_MAX_FILE_SIZE}"
       ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_CLIENT_MAX_SCAN_SIZE: "${CLAMAV_MAX_SCAN_SIZE}"
       ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_CLIENT_MAX_STREAM_LENGTH: "${CLAMAV_MAX_STREAM_LENGTH}"
-      ARCHIVEMATICA_MCPCLIENT_CLAMAV_CLIENT_BACKEND: "clamdscanner" # Option: clamdscanner or clamscan;
+      ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_CLIENT_BACKEND: "clamdscanner" # Option: clamdscanner or clamscan;
     volumes:
       - "../src/archivematica/src/archivematicaCommon/:/src/archivematicaCommon/"
       - "../src/archivematica/src/dashboard/:/src/dashboard/"


### PR DESCRIPTION
Variable name change made following previous code review, https://github.com/artefactual-labs/am/pull/25

Referenced in, https://github.com/artefactual-labs/am/issues/20 