### PR TITLE
Asks storage service tests to run in Makefile as Root

### DIFF
--- a/compose/Makefile
+++ b/compose/Makefile
@@ -120,7 +120,7 @@ test-dashboard:  ## Run Dashboard tests.
 	docker-compose run --workdir /src/dashboard --rm --user=root --entrypoint=py.test archivematica-dashboard
 
 test-storage-service:  ## Run Storage Service tests.
-	docker-compose run --workdir /src --rm --no-deps --entrypoint py.test -e "DJANGO_SETTINGS_MODULE=storage_service.settings.test" archivematica-storage-service
+	docker-compose run --workdir /src --rm --user=root --no-deps --entrypoint py.test -e "DJANGO_SETTINGS_MODULE=storage_service.settings.test" archivematica-storage-service
 
 test-at-up:
 	docker-compose -f docker-compose.yml -f docker-compose.acceptance-tests.yml up -d


### PR DESCRIPTION
The errors described in the log in this issue for the Archivematica Storage Service [#294](https://github.com/artefactual/archivematica-storage-service/issues/295) are caused by docker not being initialised with the correct permissions for the unit tests to create temporary fixture locations in the container. `-user=root` has been added to match other test calls in the Makefile. Tests now pass locally and so will resolve the storage service issue.  