### PR TITLE
Add --superuser to create_user call in SS bootstrap

### DIFF
--- a/compose/Makefile
+++ b/compose/Makefile
@@ -38,7 +38,8 @@ bootstrap-storage-service:  ## Boostrap Storage Service (new database).
 					--username="test" \
 					--password="test" \
 					--email="test@test.com" \
-					--api-key="test"
+					--api-key="test" \
+					--superuser
 	# SS needs to be restarted so the local space is created.
 	# See #303 (https://git.io/vNKlM) for more details.
 	docker-compose restart archivematica-storage-service


### PR DESCRIPTION
Now that the "test" user is not create by the Storage Service, the call to the management command to create it must now pass the ``--superuser`` flag in order to create a superuser. If not, subsequent API calls will fail because of insufficient permissions (authorization).

Connected to #56.