### PR TITLE
limit access to internal services

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     expose:
       - "3306"
     ports:
-      - "62001:3306"
+      - "127.0.0.1:62001:3306"
 
   elasticsearch:
     image: "elasticsearch:1.7-alpine"
@@ -46,7 +46,7 @@ services:
     expose:
       - "9200"
     ports:
-      - "62002:9200"
+      - "127.0.0.1:62002:9200"
 
 
   redis:
@@ -56,7 +56,7 @@ services:
     expose:
       - "6379"
     ports:
-      - "62003:6379"
+      - "127.0.0.1:62003:6379"
 
   gearmand:
     image: "artefactual/gearmand:1.1.17-alpine"
@@ -65,7 +65,7 @@ services:
     expose:
       - "4730"
     ports:
-      - "62004:4730"
+      - "127.0.0.1:62004:4730"
     links:
       - "redis"
 
@@ -74,7 +74,7 @@ services:
     expose:
       - "2113"
     ports:
-      - "62005:2113"
+      - "127.0.0.1:62005:2113"
     volumes:
       - "archivematica_pipeline_data:/var/archivematica/sharedDirectory:rw"  # Read and write needed!
 
@@ -83,7 +83,7 @@ services:
     expose:
       - "3310"
     ports:
-      - "62006:3310"
+      - "127.0.0.1:62006:3310"
     volumes:
       - "archivematica_pipeline_data:/var/archivematica/sharedDirectory:ro"
 


### PR DESCRIPTION
Changing the docker-compose file to limit all the internal services to 127.0.0.1.  
After running this, I see

```
docker-compose ps
             Name                           Command               State               Ports             
--------------------------------------------------------------------------------------------------------
compose_archivematica-           /bin/sh -c /usr/local/bin/ ...   Up      8000/tcp                      
dashboard_1                                                                                             
compose_archivematica-mcp-       /bin/sh -c /src/MCPClient/ ...   Up                                    
client_1                                                                                                
compose_archivematica-mcp-       /bin/sh -c /src/MCPServer/ ...   Up                                    
server_1                                                                                                
compose_archivematica-storage-   /bin/sh -c /usr/local/bin/ ...   Up      8000/tcp                      
service_1                                                                                               
compose_clamavd_1                /run.sh                          Up      127.0.0.1:62006->3310/tcp     
compose_elasticsearch_1          /docker-entrypoint.sh elas ...   Up      127.0.0.1:62002->9200/tcp,    
                                                                          9300/tcp                      
compose_fits_1                   /usr/bin/fits-ngserver.sh  ...   Up      127.0.0.1:62005->2113/tcp     
compose_gearmand_1               docker-entrypoint.sh --que ...   Up      127.0.0.1:62004->4730/tcp     
compose_mysql_1                  docker-entrypoint.sh mysqld      Up      127.0.0.1:62001->3306/tcp     
compose_nginx_1                  nginx -g daemon off;             Up      0.0.0.0:62080->80/tcp,        
                                                                          0.0.0.0:62081->8000/tcp       
compose_redis_1                  docker-entrypoint.sh --sav ...   Up      127.0.0.1:62003->6379/tcp

```

only the nginx ports are available outside the docker compose host

connects to #61