### PR TITLE
Compose: add make flush-logs

### DIFF
--- a/compose/Makefile
+++ b/compose/Makefile
@@ -124,8 +124,11 @@ flush-shared-dir-mcp-configs:  ## Delete processing configurations - it restarts
 flush-shared-dir:  ## Delete contents of the shared directory data volume.
 	rm -rf ${AM_PIPELINE_DATA}/*
 
-flush-elasticsearch-indices:  ## Deletes Elasticsearch indices.
+flush-elasticsearch-indices:  ## Delete Elasticsearch indices.
 	docker-compose exec archivematica-mcp-client curl -XDELETE "http://elasticsearch:9200/aips,transfers"
+
+flush-logs:  ## Delete container logs - requires root privileges.
+	@./helpers/flush-docker-logs.sh
 
 test-all: test-mcp-server test-mcp-client test-dashboard test-storage-service  ## Run all tests.
 

--- a/compose/README.md
+++ b/compose/README.md
@@ -140,6 +140,14 @@ place. Some examples:
 - `docker-compose logs -f archivematica-storage-service`
 - `docker-compose logs -f nginx archivematica-dashboard`
 
+Docker keeps the logs in files using the [JSON File logging driver][logs-0].
+If you want to clear them, we provide a simple script that can do it for us
+quickly but it needs root privileges, e.g.:
+
+    $ sudo make flush-logs
+
+[logs-0]: https://docs.docker.com/config/containers/logging/json-file/
+
 ## Scaling
 
 With Docker Compose we can run as many containers as we want for a service,

--- a/compose/helpers/flush-docker-logs.sh
+++ b/compose/helpers/flush-docker-logs.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+__compose_dir="$(cd "$(dirname "${__dir}")" && pwd)"
+
+cd ${__compose_dir}
+
+if [[ $(/usr/bin/id -u) -ne 0 ]]; then
+    echo "Not running as root."
+    exit
+fi
+
+for container_id in $(docker-compose ps --quiet); do
+    logpath=$(docker inspect --format='{{.LogPath}}' ${container_id})
+    echo "Removing ${logpath}..."
+    echo '' > $(docker inspect --format='{{.LogPath}}' ${container_id})
+done


### PR DESCRIPTION
This PR adds a new make goal to clear the logs of the Docker containers.

    $ sudo make flush-logs

It requires root privileges.

It's useful when you've been using the same containers for a long time and running `docker-compose logs ...` prints so much output that becomes unmanageable.