### PR TITLE
Compose: move named volumes to homedir

### DIFF
--- a/compose/Makefile
+++ b/compose/Makefile
@@ -1,8 +1,7 @@
 
 # Paths for Docker named volumes
-AM_PIPELINE_DATA ?= /tmp/am-pipeline-data
-SS_LOCATION_DATA ?= /tmp/ss-location-data
-
+AM_PIPELINE_DATA ?= $(HOME)/.am/am-pipeline-data
+SS_LOCATION_DATA ?= $(HOME)/.am/ss-location-data
 
 create-volumes:  ## Create external data volumes.
 	mkdir -p ${AM_PIPELINE_DATA}

--- a/compose/README.md
+++ b/compose/README.md
@@ -80,8 +80,8 @@ These are the commands you need to run when starting from scratch:
 `make create-volumes` creates two external volumes. They're heavily used in our
 containers but they are provided in the host machine:
 
-- `/tmp/am-pipeline-data` - the shared directory.
-- `/tmp/ss-location-data` - the transfer source location.
+- `$HOME/.am/am-pipeline-data` - the shared directory.
+- `$HOME/.am/ss-location-data` - the transfer source location.
 
 ### GNU make
 
@@ -215,7 +215,7 @@ volumes manually with:
 
 Optionally you may also want to delete the directories:
 
-    $ rm -rf /tmp/am-pipeline-data /tmp/ss-location-data
+    $ rm -rf $HOME/.am/am-pipeline-data $HOME/.am/ss-location-data
 
 ## Troubleshooting
 
@@ -287,7 +287,7 @@ frequently happens when you restart your machine.
 Under this scenario, if you try to bring up the services again you will likely
 see one or more errors like the following:
 
-    ERROR: for compose_archivematica-mcp-server_1  Cannot create container for service archivematica-mcp-server: error while mounting volume with options: type='none' device='/tmp/am-pipeline-data' o='bind': no such file or directory
+    ERROR: for compose_archivematica-mcp-server_1  Cannot create container for service archivematica-mcp-server: error while mounting volume with options: type='none' device='/home/user/.am/am-pipeline-data' o='bind': no such file or directory
 
 The solution is simple. You need to create the volumes again:
 
@@ -301,8 +301,8 @@ Optionally, you can define new persistent locations for the external volumes.
 The defaults are defined in the `Makefile`:
 
     # Paths for Docker named volumes
-    AM_PIPELINE_DATA ?= /tmp/am-pipeline-data
-    SS_LOCATION_DATA ?= /tmp/ss-location-data
+    AM_PIPELINE_DATA ?= $(HOME)/.am/am-pipeline-data
+    SS_LOCATION_DATA ?= $(HOME)/.am/ss-location-data
 
 ##### Tests are too slow
 


### PR DESCRIPTION
This PR changes the default locations of the named external volumes `am-pipeline-data` and `ss-location-data` in our Compose development environment. We used to have then under `/tmp` which was problematic for different reasons, e.g. permission errors in Docker for Mac, lack of persistency, etc...

Thew new locations are:
- `$HOME/.am/am-pipeline-data`
- `$HOME/.am/ss-location-data`

Once this is merged, you need to tell Docker that you want to remove the old volumes:

    docker volume rm am-pipeline-data
    docker volume rm ss-location-data

Then create them again with:

    make create-volumes

And confirm that they've been created properly with:

docker volume inspect --format "{{ .Options.device }}" am-pipeline-data
docker volume inspect --format "{{ .Options.device }}" ss-location-data

CC @ablwr - I've added you as a member of this org but you need to accept the invitation.

Related issues:
- https://github.com/artefactual-labs/am/issues/4
- https://github.com/artefactual-labs/am/issues/34
- https://github.com/artefactual-labs/am/issues/49
