### PR TITLE
Use MySQL utf8/utf8_general

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -28,6 +28,7 @@ services:
   mysql:
     image: "percona:5.6"
     user: "mysql"
+    command: --character-set-server=utf8 --collation-server=utf8_general_ci
     environment:
       MYSQL_ROOT_PASSWORD: "12345"
     volumes:


### PR DESCRIPTION
Seems like we should be consistent with how installs are done via Ansible.