### PR TITLE
Add recipe for testing archivematica-common

### DIFF
--- a/compose/Makefile
+++ b/compose/Makefile
@@ -147,6 +147,9 @@ test-dashboard:  ## Run Dashboard tests.
 test-storage-service:  ## Run Storage Service tests.
 	docker-compose run --workdir /src --rm --no-deps --entrypoint py.test -e "DJANGO_SETTINGS_MODULE=storage_service.settings.test" archivematica-storage-service -p no:cacheprovider --reuse-db -v
 
+test-archivematica-common:  ## Run Archivematica Common tests.
+	docker-compose run --workdir /src/archivematicaCommon --rm --entrypoint py.test archivematica-mcp-client -p no:cacheprovider -p no:warnings --reuse-db -v
+
 test-at-build:  ## AMAUAT: build image.
 	$(call compose_amauat, \
 		build archivematica-acceptance-tests)


### PR DESCRIPTION
We need to be able to test these from the our development environment. This is just one approach, but happy to change these and get them merged so that we're able to use this recipe. 

Connected to #55 