### PR TITLE
Add compile-requirements command

### DIFF
--- a/compose/Makefile
+++ b/compose/Makefile
@@ -113,7 +113,7 @@ restart-am-services:  ## Restart Archivematica services: MCPServer, MCPClient, D
 
 compile-requirements:  ## Run pip-compile
 	docker-compose run --workdir /src/MCPServer/requirements --volume "tmpfs:/pip-cache:rw" -e XDG_CACHE_HOME=/pip-cache --rm  --no-deps --user=root --entrypoint make archivematica-mcp-server all
-	docker-compose run --workdir /src/MCPClient/requirements --volume "tmpfs:/pip-cache:rw" --rm --no-deps --user=root --entrypoint make archivematica-mcp-client all
+	docker-compose run --workdir /src/MCPClient/requirements --volume "tmpfs:/pip-cache:rw" -e XDG_CACHE_HOME=/pip-cache --rm --no-deps --user=root --entrypoint make archivematica-mcp-client all
 	docker-compose run --workdir /src/dashboard/src/requirements --volume "tmpfs:/pip-cache:rw" -e XDG_CACHE_HOME=/pip-cache --rm --no-deps --user=root --entrypoint make archivematica-dashboard all
 	docker-compose run --workdir /src/requirements --volume "tmpfs:/pip-cache:rw" -e XDG_CACHE_HOME=/pip-cache --rm  --no-deps --user=root --entrypoint make archivematica-storage-service all
 

--- a/compose/Makefile
+++ b/compose/Makefile
@@ -111,6 +111,12 @@ restart-am-services:  ## Restart Archivematica services: MCPServer, MCPClient, D
 	docker-compose restart archivematica-dashboard
 	docker-compose restart archivematica-storage-service
 
+compile-requirements:  ## Run pip-compile
+	docker-compose run --workdir /src/MCPServer/requirements --volume "tmpfs:/pip-cache:rw" -e XDG_CACHE_HOME=/pip-cache --rm  --no-deps --user=root --entrypoint make archivematica-mcp-server all
+	docker-compose run --workdir /src/MCPClient/requirements --volume "tmpfs:/pip-cache:rw" --rm --no-deps --user=root --entrypoint make archivematica-mcp-client all
+	docker-compose run --workdir /src/dashboard/src/requirements --volume "tmpfs:/pip-cache:rw" -e XDG_CACHE_HOME=/pip-cache --rm --no-deps --user=root --entrypoint make archivematica-dashboard all
+	docker-compose run --workdir /src/requirements --volume "tmpfs:/pip-cache:rw" -e XDG_CACHE_HOME=/pip-cache --rm  --no-deps --user=root --entrypoint make archivematica-storage-service all
+
 db:  ## Connect to the MySQL server using the CLI.
 	docker-compose exec mysql mysql -hlocalhost -uroot -p12345
 


### PR DESCRIPTION
Relates to: https://github.com/archivematica/Issues/issues/765

We've been having some consistency issues running pip-compile; this change hopefully addresses them via docker standardization:

* avoids platform specific additions/removals (seen with the `appnope` package)
* runs a consistent version of pip-compile (3.7.0, tagged in dev.in files)
* uses a consistent version of python

To test, checkout this branch, make a change to a .in file, and run `make compile-requirements`