### PR TITLE
WIP: Add Django commands for translating strings

### DIFF
--- a/compose/Makefile
+++ b/compose/Makefile
@@ -71,6 +71,16 @@ manage-ss:  ## Run Django /manage.py on Storage Service, suppling <command> [opt
 			archivematica-storage-service \
 				$(ARG)
 
+make-messages:  ## Build Django translation files
+	docker-compose run --workdir /src/dashboard/src \
+		--rm --no-deps --user=root \
+		--entrypoint /src/dashboard/src/manage.py archivematica-dashboard makemessages
+
+compile-messages: 	## Build Django translation files
+	docker-compose run \
+		--rm --no-deps --user=root \
+		--entrypoint /src/dashboard/src/manage.py archivematica-dashboard compilemessages
+
 bootstrap-dashboard-db:  ## Bootstrap Dashboard (new database).
 	docker-compose exec mysql mysql -hlocalhost -uroot -p12345 -e "\
 		DROP DATABASE IF EXISTS MCP; \

--- a/compose/Makefile
+++ b/compose/Makefile
@@ -76,6 +76,11 @@ translate-make-messages-am:  ## Translation: Export message files for translatio
 		--rm --no-deps --user=root \
 		--entrypoint /src/dashboard/src/manage.py archivematica-dashboard makemessages
 
+translate-make-messages-am-js:  ## Translation: Export message files for translation from Archivematica
+	docker-compose run --workdir /src/dashboard/src \
+		--rm --no-deps --user=root \
+		--entrypoint /src/dashboard/src/manage.py archivematica-dashboard makemessages -d djangojs
+
 translate-compile-messages-am: 	## Translation: Compile message files for Archivematica's use at runtime
 	docker-compose run \
 		--rm --no-deps --user=root \
@@ -85,6 +90,11 @@ translate-make-messages-ss:  ## Translation: Export message files for translatio
 	docker-compose run \
 		--rm --user=root \
 		--entrypoint /src/storage_service/manage.py archivematica-storage-service makemessages
+
+translate-make-messages-js:  ## Translation: Export message files for translation from the Storage Service
+	docker-compose run \
+		--rm --user=root \
+		--entrypoint /src/storage_service/manage.py archivematica-storage-service makemessages -d djangojs
 
 translate-compile-messages-ss: 	## Translation: Compile message files for the Storage Service's use at runtime
 	docker-compose run \

--- a/compose/Makefile
+++ b/compose/Makefile
@@ -81,6 +81,16 @@ compile-messages: 	## Build Django translation files
 		--rm --no-deps --user=root \
 		--entrypoint /src/dashboard/src/manage.py archivematica-dashboard compilemessages
 
+make-messages-ss:  ## Build Django translation files for the storage service
+	docker-compose run \
+		--rm --user=root \
+		--entrypoint /src/storage_service/manage.py archivematica-storage-service makemessages
+
+compile-messages-ss: 	## Build Django translation files for the storage service
+	docker-compose run \
+		--rm --user=root \
+		--entrypoint /src/storage_service/manage.py archivematica-storage-service compilemessages
+
 bootstrap-dashboard-db:  ## Bootstrap Dashboard (new database).
 	docker-compose exec mysql mysql -hlocalhost -uroot -p12345 -e "\
 		DROP DATABASE IF EXISTS MCP; \

--- a/compose/Makefile
+++ b/compose/Makefile
@@ -82,12 +82,12 @@ translate-make-messages-am-js:  ## Translation: Export message files for transla
 		--entrypoint /src/dashboard/src/manage.py archivematica-dashboard makemessages -d djangojs
 
 translate-compile-messages-am: 	## Translation: Compile message files for Archivematica's use at runtime
-	docker-compose run \
+	docker-compose run --workdir /src/dashboard/src \
 		--rm --no-deps --user=root \
 		--entrypoint /src/dashboard/src/manage.py archivematica-dashboard compilemessages
 
 translate-make-messages-ss:  ## Translation: Export message files for translation from the Storage Service
-	docker-compose run \
+	docker-compose run --workdir /src \
 		--rm --user=root \
 		--entrypoint /src/storage_service/manage.py archivematica-storage-service makemessages
 

--- a/compose/Makefile
+++ b/compose/Makefile
@@ -71,22 +71,22 @@ manage-ss:  ## Run Django /manage.py on Storage Service, suppling <command> [opt
 			archivematica-storage-service \
 				$(ARG)
 
-make-messages:  ## Build Django translation files
+translate-make-messages-am:  ## Translation: Export message files for translation from Archivematica
 	docker-compose run --workdir /src/dashboard/src \
 		--rm --no-deps --user=root \
 		--entrypoint /src/dashboard/src/manage.py archivematica-dashboard makemessages
 
-compile-messages: 	## Build Django translation files
+translate-compile-messages-am: 	## Translation: Compile message files for Archivematica's use at runtime
 	docker-compose run \
 		--rm --no-deps --user=root \
 		--entrypoint /src/dashboard/src/manage.py archivematica-dashboard compilemessages
 
-make-messages-ss:  ## Build Django translation files for the storage service
+translate-make-messages-ss:  ## Translation: Export message files for translation from the Storage Service
 	docker-compose run \
 		--rm --user=root \
 		--entrypoint /src/storage_service/manage.py archivematica-storage-service makemessages
 
-compile-messages-ss: 	## Build Django translation files for the storage service
+translate-compile-messages-ss: 	## Translation: Compile message files for the Storage Service's use at runtime
 	docker-compose run \
 		--rm --user=root \
 		--entrypoint /src/storage_service/manage.py archivematica-storage-service compilemessages


### PR DESCRIPTION
This commit provides helpers for developers looking to transform
Archivematica strings into a suitable format for translation.

**NB.** the primary difference between these commands and existing manage commands is the ability for the container to use root. This may still not be the right solution. 

Connected to archivematica/issues#984 

Questions: 

* Do we create two other commands for the storage service? (or combine into one?)
* What other components are missing? e.g. Angular instructions? 