### PR TITLE
Create complete recipes for pip-compile

### DIFF
--- a/compose/Makefile
+++ b/compose/Makefile
@@ -4,6 +4,8 @@
 AM_PIPELINE_DATA ?= $(HOME)/.am/am-pipeline-data
 SS_LOCATION_DATA ?= $(HOME)/.am/ss-location-data
 
+CALLER_UID=$(shell id -u)
+CALLER_GID=$(shell id -g)
 
 define compose_amauat
 	docker-compose -f docker-compose.yml -f docker-compose.acceptance-tests.yml $(1)
@@ -111,12 +113,45 @@ restart-am-services:  ## Restart Archivematica services: MCPServer, MCPClient, D
 	docker-compose restart archivematica-dashboard
 	docker-compose restart archivematica-storage-service
 
-compile-requirements:  ## Run pip-compile
-	docker-compose run --workdir /src/archivematicaCommon/requirements --volume "tmpfs:/pip-cache:rw" -e XDG_CACHE_HOME=/pip-cache --rm  --no-deps --user=root --entrypoint make archivematica-mcp-server all
-	docker-compose run --workdir /src/MCPServer/requirements --volume "tmpfs:/pip-cache:rw" -e XDG_CACHE_HOME=/pip-cache --rm  --no-deps --user=root --entrypoint make archivematica-mcp-server all
-	docker-compose run --workdir /src/MCPClient/requirements --volume "tmpfs:/pip-cache:rw" -e XDG_CACHE_HOME=/pip-cache --rm --no-deps --user=root --entrypoint make archivematica-mcp-client all
-	docker-compose run --workdir /src/dashboard/src/requirements --volume "tmpfs:/pip-cache:rw" -e XDG_CACHE_HOME=/pip-cache --rm --no-deps --user=root --entrypoint make archivematica-dashboard all
-	docker-compose run --workdir /src/requirements --volume "tmpfs:/pip-cache:rw" -e XDG_CACHE_HOME=/pip-cache --rm  --no-deps --user=root --entrypoint make archivematica-storage-service all
+compile-requirements-am:  ## Run pip-compile for Archivematica
+	docker-compose run --workdir /src/MCPServer/requirements \
+		-e XDG_CACHE_HOME=/tmp/pip-cache \
+		--rm  \
+		--no-deps \
+		--user=$(CALLER_UID):$(CALLER_GID) \
+		--entrypoint bash archivematica-mcp-server \
+			-c "make clean && make all"
+
+	docker-compose run --workdir /src/MCPClient/requirements \
+		-e XDG_CACHE_HOME=/tmp/pip-cache \
+		--rm \
+		--no-deps \
+		--user=$(CALLER_UID):$(CALLER_GID) \
+		--entrypoint bash archivematica-mcp-client \
+			-c "make clean && make all"
+	docker-compose run --workdir /src/dashboard/src/requirements \
+		-e XDG_CACHE_HOME=/tmp/pip-cache \
+		--rm \
+		--no-deps \
+		--user=$(CALLER_UID):$(CALLER_GID) \
+		--entrypoint bash archivematica-dashboard \
+			-c "make clean && make all"
+	docker-compose run --workdir /src/archivematicaCommon/requirements \
+		-e XDG_CACHE_HOME=/tmp/pip-cache \
+		--rm \
+		--no-deps \
+		--user=$(CALLER_UID):$(CALLER_GID) \
+		--entrypoint bash archivematica-dashboard \
+			-c "make clean && make all"
+
+compile-requirements-ss:  ## Run pip-compile for Storage Service
+	docker-compose run --workdir /src/requirements \
+		-e XDG_CACHE_HOME=/tmp/pip-cache \
+		--rm  \
+		--no-deps \
+		--user=$(CALLER_UID):$(CALLER_GID) \
+		--entrypoint bash archivematica-storage-service \
+			-c "make clean && make all"
 
 db:  ## Connect to the MySQL server using the CLI.
 	docker-compose exec mysql mysql -hlocalhost -uroot -p12345


### PR DESCRIPTION
This commit introduces a storage service command for pip-compile and
ensures that for both Archivematica and the Storage Service
permissions are updated so that they remain usable by the caller,
i.e. permissions are reset to 0644 and ownership reset to the
user-space UID for the current login and not root for sudo callers.

For usability the two commands to test are:

* `reset-permissions-to-user-am`
* `reset-permissions-to-user-ss`

With `-am` and `-ss` at the end of the command, they are easier to exchange vs. mid-string. 

The last three commits today (Aug 5) should be the ones reviewed here and will make up the re-base. 

One additional point of note is that previously I thought `all` meant a clean and compile. I hadn't studied the compile Makefiles too carefully. Without a clean step this has tripped us up a few times, either testing this particular PR, or other related compile PRs. I've therefore implemented a clean-and-compile approach to this which, while it takes longer, is better practice in the long-run. I'd like us to stick with those given the option. 

Connected to archivematica/issues#1039
Requires https://github.com/artefactual/archivematica-storage-service/pull/540 (see notes)