### PR TITLE
Add MySQL config file to override default settings

### DIFF
--- a/compose/README.md
+++ b/compose/README.md
@@ -318,6 +318,14 @@ Optionally you may also want to delete the directories:
 
     $ rm -rf $HOME/.am/am-pipeline-data $HOME/.am/ss-location-data
 
+## Percona tuning
+
+To use different settings on the MySQL container, please edit the
+`etc/mysql/tunning.conf` file and rebuild the container with:
+
+    $ docker down
+    $ docker-compose up -d
+
 ## Instrumentation
 
 ### Running Prometheus and Grafana

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -32,6 +32,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: "12345"
     volumes:
+      - "./etc/mysql/tuning.cnf:/etc/my.cnf.d/tuning.cnf:ro"
       - "mysql_data:/var/lib/mysql"
     ports:
       - "127.0.0.1:62001:3306"

--- a/compose/etc/mysql/tuning.cnf
+++ b/compose/etc/mysql/tuning.cnf
@@ -2,7 +2,7 @@
 
 innodb_log_file_size=64M
 max_allowed_packet=256M
-mysql_innodb_buffer_pool_size=256M
+innodb_buffer_pool_size=256M
 
 # Large scale settings
 #innodb_log_file_size=1G

--- a/compose/etc/mysql/tuning.cnf
+++ b/compose/etc/mysql/tuning.cnf
@@ -7,4 +7,4 @@ mysql_innodb_buffer_pool_size=256M
 # Large scale settings
 #innodb_log_file_size=1G
 #max_allowed_packet=1G
-#mysql_innodb_buffer_pool_size=256M
+#innodb_buffer_pool_size=256M

--- a/compose/etc/mysql/tuning.cnf
+++ b/compose/etc/mysql/tuning.cnf
@@ -1,0 +1,10 @@
+[mysqld]
+
+innodb_log_file_size=64M
+max_allowed_packet=256M
+mysql_innodb_buffer_pool_size=256M
+
+# Large scale settings
+#innodb_log_file_size=1G
+#max_allowed_packet=1G
+#mysql_innodb_buffer_pool_size=256M


### PR DESCRIPTION
The new `am-tuning.cnf` file overrides some MySQL settings that are often too
low in default deployments.

The following variables have been added to the file:

* max_allowed_packet = 1G
* innodb_log_file_size = 1G

Mounting the `am-tuning.cnf` as a new volume with a relative path on the docker
host allows to apply changes in MySQL easily. The user only needs to change
that file in the docker host, and then restart or rebuild the container.

Connects to https://github.com/archivematica/Issues/issues/956